### PR TITLE
support random destination path

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -28,16 +28,19 @@ Handlebars.registerHelper('unless_eq', function (a, b, opts) {
  * @param {String} src
  * @param {String} dest
  * @param {Function} done
+ * @param {boolean} isRandomPath
  */
 
-module.exports = function generate (name, src, dest, done) {
+module.exports = function generate (name, src, dest, done, isRandomPath) {
   const opts = getOptions(name, src);
   const metalsmith = Metalsmith(path.join(src, 'template'));
+  // if dest is a random path then pass it to templates
+  const randomPath = isRandomPath ? { dest } : {};
   const data = Object.assign(metalsmith.metadata(), {
     destDirName: name,
     inPlace: dest === process.cwd(),
     noEscape: true
-  });
+  }, randomPath);
   opts.helpers && Object.keys(opts.helpers).map(key => {
     Handlebars.registerHelper(key, opts.helpers[key]);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,20 @@ const getTemplatePath = localpath.getTemplatePath;
  * @param {string} dir - directory where the project will be created. Required.
  * @param {string} dirname - name of the directory. Required
  * @param {string} template - tempalte name. Required.
+ * @param {boolean} isRandomPath - whether dir is a random path that user assigned
  */
-module.exports = (dir, dirname, template, extEvents, options) => {
+module.exports = (dir, dirname, template, extEvents, options, isRandomPath) => {
+  if (typeof extEvents === 'boolean') {
+    isRandomPath = extEvents;
+    extEvents = null;
+    options = null;
+  } else if (typeof options === 'boolean') {
+    isRandomPath = options;
+    options = null;
+  }
+
   return new Promise((resolve, reject) => {
-    if (extEvents) {
+    if (extEvents && typeof extEvents !== 'boolean') {
       logger.setupEvents(extEvents);
     }
     if (isLocalPath(template)) {
@@ -27,7 +37,7 @@ module.exports = (dir, dirname, template, extEvents, options) => {
         generate(dirname, templatePath, dir, err => {
           if (err) logger.error(err);
           logger.success(`Generated ${dirname}`);
-        });
+        }, isRandomPath);
       }
       else {
         logger.error(`Local template "${template}" not found.`);
@@ -46,7 +56,7 @@ module.exports = (dir, dirname, template, extEvents, options) => {
         generate(dirname, tmp, dir, err => {
           if (err) logger.error(err);
           logger.success(`Generated ${dirname}`);
-        });
+        }, isRandomPath);
       });
     }
   });


### PR DESCRIPTION
When using [weexpack-create](https://github.com/weexteam/weexpack-create) to create a weex project with a random assigned path, the code works well too.
```javascript
const weexpackCreate = require('weexpack-create');

weexpackCreate(
  randomPath, // e.g. /Users/xuzuo/work/learn-weex
  'learn-weex',
  'github-repository',
  true, // 支持randomPath
);
```
@erha19 